### PR TITLE
Bump opencv version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "example": "examples"
   },
   "dependencies": {
-    "opencv": "~0.0.9",
+    "opencv": "~0.3.1",
     "underscore": "~1.4.4"
   },
   "devDependencies": {},


### PR DESCRIPTION
Bumps the opencv dependency from 0.0.9 to 0.3.1. This removes eio_req error on install and fixes #2.
