### PR TITLE
Fix issue #7: Feature points gone wrong

### DIFF
--- a/examples/identify.js
+++ b/examples/identify.js
@@ -23,7 +23,7 @@ function worker(faces, image, file) {
     function draw(feature, color) {
         image.rectangle(
             [feature.getX(), feature.getY()],
-            [feature.getX2(), feature.getY2()],
+            [feature.getWidth(), feature.getHeight()],
             color,
             2
         );


### PR DESCRIPTION
The reason is the rectangle function. According to http://docs.opencv.org/2.4/modules/core/doc/drawing_functions.html (it doesn't have a js example), you should pass [x,y], [width,height] Not [x,y], [width+x, height+y]. I confirmed this further by looking into their C++ code. OpenCV seems to take care of it for you.

cv::rectangle(self->mat, cv::Point(x, y), cv::Point(x + width, y + height),
        color, thickness);

Thus, getX2 and getY2 should be replaced with getWidth and getHeight subsequently.
